### PR TITLE
受講生情報を更新するメソッドを追加

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -9,6 +9,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import raisetech.StudentManagement.controller.converter.StudentConverter;
 import raisetech.StudentManagement.data.Student;
@@ -48,12 +49,14 @@ public class StudentController {
     return "studentCourseList";
   }
 
+  // 受講生の新規登録画面です。
   @GetMapping("/newStudent")
   public String newStudent(Model model) {
     model.addAttribute("studentDetail", new StudentDetail());
     return "registerStudent";
   }
 
+  // 受講生の新規登録を行います。
   @PostMapping("/registerStudent")
   public String registerStudent(@ModelAttribute @Valid StudentDetail studentDetail,
       BindingResult result, Model model) {
@@ -71,6 +74,31 @@ public class StudentController {
     service.registerStudent(studentDetail);
     service.registerStudentCourse(studentDetail);
 
+    return "redirect:/studentList";
+  }
+
+  @GetMapping("/student/{studentId}")
+  public String getStudent(@PathVariable String studentId, Model model) {
+    StudentDetail studentDetail = service.searchStudentDetail(studentId);
+    model.addAttribute("studentDetail", studentDetail);
+    return "updateStudent";
+  }
+
+
+  @PostMapping("/updateStudent")
+  public String updateStudent(@ModelAttribute @Valid StudentDetail studentDetail,
+      BindingResult result, Model model) {
+    // 重複チェック
+    if (service.hasDuplicateCourses(studentDetail)) {
+      result.rejectValue("studentCourses", "error.studentCourses",
+          "重複したコース名は登録できません");
+    }
+    // 入力エラーチェック
+    if (result.hasErrors()) {
+      result.getAllErrors().forEach(error -> System.out.println(error.getDefaultMessage()));
+      return "registerStudent";
+    }
+    service.updateStudent(studentDetail);
     return "redirect:/studentList";
   }
 

--- a/src/main/java/raisetech/StudentManagement/domain/StudentDetail.java
+++ b/src/main/java/raisetech/StudentManagement/domain/StudentDetail.java
@@ -13,6 +13,7 @@ public class StudentDetail {
 
   @Valid
   private Student student;
-  
+
+  @Valid
   private List<StudentCourse> studentCourses;
 }

--- a/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
+++ b/src/main/java/raisetech/StudentManagement/repository/StudentRepository.java
@@ -6,6 +6,7 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 import raisetech.StudentManagement.data.Student;
 import raisetech.StudentManagement.data.StudentCourse;
 
@@ -23,10 +24,15 @@ public interface StudentRepository {
    * @return 全件検索した受講生情報の一覧
    */
   @Select("SELECT * FROM students")
-  List<Student> search();
+  List<Student> searchStudentList();
 
+  /**
+   * 受講生コースを全件検索します。
+   *
+   * @return 全件検索した受講生コース情報の一覧
+   */
   @Select("SELECT * FROM students_courses")
-  List<StudentCourse> searchStudentsCourses();
+  List<StudentCourse> searchStudentsCoursesList();
 
   /**
    * 入力フォームから受け取ったデータをDBに登録します。
@@ -45,5 +51,32 @@ public interface StudentRepository {
           + "(#{course.studentId}, #{course.courseName}, #{course.startDate}, #{course.expectedEndDate})</foreach></script>"})
   @Options(useGeneratedKeys = true, keyProperty = "studentId")
   void registerStudentCourses(@Param("studentCourse") List<StudentCourse> studentCourse);
+
+  // 受講生　単一検索
+  @Select("SELECT * FROM students WHERE student_id = #{id}")
+  Student searchStudent(String studentId);
+
+  // 受講生コース　単一検索
+  @Select("SELECT * FROM students_Courses WHERE student_id = #{id}")
+  List<StudentCourse> searchStudentCourses(String studentId);
+
+  /**
+   * 受講生情報の更新されたデータをDBに登録します。
+   *
+   * @param student
+   */
+  @Update(
+      "UPDATE students SET name = #{name}, furigana = #{furigana}, nickname = #{nickname}, "
+          + "email_address = #{emailAddress}, residential_area = #{residentialArea}, age = #{age}, gender = #{gender}, remark = #{remark}"
+          + "WHERE student_id = #{studentId}")
+  void updateStudent(Student student);
+
+  /**
+   * 受講コースの更新されたデータをDBに登録します。
+   *
+   * @param studentCourse
+   */
+  @Update("UPDATE students_courses SET course_name = #{courseName} WHERE course_id = #{courseId}")
+  void updateStudentCourses(StudentCourse studentCourse);
 
 }

--- a/src/main/java/raisetech/StudentManagement/service/StudentService.java
+++ b/src/main/java/raisetech/StudentManagement/service/StudentService.java
@@ -22,19 +22,23 @@ public class StudentService {
     this.repository = repository;
   }
 
+  // 受講生情報を一覧で取得します
   public List<Student> searchStudentList() {
-    return repository.search();
+    return repository.searchStudentList();
   }
 
+  // 受講コース情報を一覧で取得します。
   public List<StudentCourse> searchStudentsCourseList() {
-    return repository.searchStudentsCourses();
+    return repository.searchStudentsCoursesList();
   }
 
+  // 受講生登録を行います
   @Transactional
   public void registerStudent(StudentDetail studentDetail) {
     repository.registerStudent(studentDetail.getStudent());
   }
 
+  // 受講コース情報の登録を行います
   @Transactional
   public void registerStudentCourse(StudentDetail studentDetail) {
 
@@ -46,6 +50,7 @@ public class StudentService {
     repository.registerStudentCourses(studentDetail.getStudentCourses());
   }
 
+  // コース情報の重複チェックを行うメソッドです。
   public boolean hasDuplicateCourses(StudentDetail studentDetail) {
     List<String> courseNames = studentDetail.getStudentCourses().stream()
         .map(StudentCourse::getCourseName)
@@ -55,4 +60,25 @@ public class StudentService {
     Set<String> uniqueCourses = new HashSet<>(courseNames);
     return uniqueCourses.size() != courseNames.size();
   }
+
+  // 受講生情報とコース情報の単一検索
+  public StudentDetail searchStudentDetail(String studentId) {
+    Student student = repository.searchStudent(studentId);
+    List<StudentCourse> studentCourse = repository.searchStudentCourses(student.getStudentId());
+    StudentDetail studentDetail = new StudentDetail();
+    studentDetail.setStudent(student);
+    studentDetail.setStudentCourses(studentCourse);
+    return studentDetail;
+  }
+
+  @Transactional
+  public void updateStudent(StudentDetail studentDetail) {
+
+    repository.updateStudent(studentDetail.getStudent());
+    for (StudentCourse studentCourse : studentDetail.getStudentCourses()) {
+      studentCourse.setStudentId(studentDetail.getStudent().getStudentId());
+      repository.updateStudentCourses(studentCourse);
+    }
+  }
+
 }

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -24,8 +24,8 @@
   <tbody>
   <tr th:each="studentDetail : ${studentList}">
     <td th:text="${studentDetail.student.studentId}">1</td>
-    <td th:text="${studentDetail.student.name}">山田太郎</a>
-    </td>
+    <td><a th:text="${studentDetail.student.name}"
+           th:href="@{/student/{id}(id=${studentDetail.student.studentId})}">山田太郎</a></td>
     <td th:text="${studentDetail.student.furigana}">ヤマダタロウ</td>
     <td th:text="${studentDetail.student.nickname}">タロちゃん</td>
     <td th:text="${studentDetail.student.emailAddress}">taro.yamada@example.com</td>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <title>受講生更新</title>
+</head>
+<body>
+<h1>受講生更新</h1>
+<form th:action="@{/updateStudent}" th:object="${studentDetail}" method="post">
+  <div>
+    <label for="studentId">ID</label>
+    <input type="text" id="studentId" th:field="*{student.studentId}" required/>
+  </div>
+  <div>
+    <label for="name">名前</label>
+    <input type="text" id="name" th:field="*{student.name}" required/>
+    <div th:if="${#fields.hasErrors('student.name')}" th:errors="*{student.name}"></div>
+  </div>
+  <div>
+    <label for="furigana">フリガナ</label>
+    <input type="text" id="furigana" th:field="*{student.furigana}" required/>
+  </div>
+  <div>
+    <label for="nickname">ニックネーム</label>
+    <input type="text" id="nickname" th:field="*{student.nickname}" required/>
+  </div>
+  <div>
+    <label for="emailAddress">メールアドレス</label>
+    <input type="email" id="emailAddress" th:field="*{student.emailAddress}" required
+           pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$"
+           title="有効なメールアドレスを入力してください（例: example@example.com）">
+  </div>
+  <div>
+    <label for="residentialArea">地域</label>
+    <input type="text" id="residentialArea" th:field="*{student.residentialArea}" required/>
+  </div>
+  <div>
+    <label for="age">年齢</label>
+    <input type="number" id="age" th:field="*{student.age}" min="0" max="100" required/>
+  </div>
+  <div>
+    <span>性別</span>
+    <input type="radio" id="male" name="student.gender" value="男性" th:field="*{student.gender}"/>
+    <label for="male">男性</label>
+    <input type="radio" id="female" name="student.gender" value="女性"
+           th:field="*{student.gender}"/>
+    <label for="female">女性</label>
+    <input type="radio" id="other" name="student.gender" value="その他"
+           th:field="*{student.gender}"/>
+    <label for="other">その他</label>
+  </div>
+  <div>
+    <label for="remark">備考</label>
+    <input type="text" id="remark" th:field="*{student.remark}">
+  </div>
+  <div>
+    <label for="courseId1">受講コースID①</label>
+    <input type="text" id="courseId1" th:field="*{studentCourses[0].courseId}"/>
+
+    <label for="courseName1">コース名①</label>
+    <select id="courseName1" th:field="*{StudentCourses[0].courseName}">
+      <option value="Javaコース">Javaコース</option>
+      <option value="AWSコース">AWSコース</option>
+      <option value="デザインコース">デザインコース</option>
+      <option value="WPコース">WPコース</option>
+      <option value="Webマーケティングコース">Webマーケティングコース</option>
+    </select>
+  </div>
+  <div>
+    <label for="courseId2">受講コースID②</label>
+    <input type="text" id="courseId2" th:field="*{studentCourses[1].courseId}"/>
+
+    <label for="courseName2">コース名②</label>
+    <select id="courseName2" th:field="*{StudentCourses[1].courseName}">
+      <option value="Javaコース">Javaコース</option>
+      <option value="AWSコース">AWSコース</option>
+      <option value="デザインコース">デザインコース</option>
+      <option value="WPコース">WPコース</option>
+      <option value="Webマーケティングコース">Webマーケティングコース</option>
+    </select>
+  </div>
+
+  <!-- エラーメッセージを表示 -->
+  <div th:if="${#fields.hasErrors('studentCourses')}" th:errors="*{studentCourses}"></div>
+
+  <div>
+    <button type="submit">更新</button>
+  </div>
+</form>
+</body>
+</html>


### PR DESCRIPTION
・前段階として受講生を単一で検索するメソッドを追加
・単一で検索した受講生に紐づくコース情報を検索するメソッドを追加
・更新するためのHTMLを追加
・単一検索するための<a>タグをstudentList.htmlに追加

以下、実行画面の結果です。
①<a>タグを追加し、受講生一覧の画面に表示された受講生の名前を押下することによって、受講生単一情報を表示させます。
<img width="1160" alt="スクリーンショット 2024-12-28 15 01 22" src="https://github.com/user-attachments/assets/d041c193-e485-4190-8bbe-95296d1b89ab" />

<img width="552" alt="スクリーンショット 2024-12-28 15 01 42" src="https://github.com/user-attachments/assets/24835a1a-9956-4807-9296-bc8438bbdeb7" />

②ID：1の山田太郎さんを更新します。
・年齢を24歳から30歳へ変更
・受講コースをJavaコースとAWSコースから、デザインコースとWPコースへ変更
<img width="588" alt="スクリーンショット 2024-12-28 15 03 32" src="https://github.com/user-attachments/assets/eb07bee4-55b6-4b4d-8e67-1073e22eefbb" />

<img width="1140" alt="スクリーンショット 2024-12-28 15 03 57" src="https://github.com/user-attachments/assets/23a1dc9d-bcca-454c-a8bc-5d073a1d8ad9" />

