### PR TITLE
36回課題_エラーを投げてみる専用メソッドを追加

### DIFF
--- a/src/main/java/raisetech/StudentManagement/controller/StudentController.java
+++ b/src/main/java/raisetech/StudentManagement/controller/StudentController.java
@@ -1,6 +1,7 @@
 package raisetech.StudentManagement.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,8 +41,14 @@ public class StudentController {
    */
   @GetMapping("/students")
   public List<StudentDetail> getStudentList() {
+    // エラーを投げてみる
+    if (shouldThrowError()) {
+      throw new ResponseStatusException(
+          HttpStatus.INTERNAL_SERVER_ERROR,
+          "意図的なエラーを発生させました"
+      );
+    }
     return service.searchStudentList();
-
   }
 
   /**
@@ -52,7 +59,8 @@ public class StudentController {
    * @return 受講生詳細
    */
   @GetMapping("/students/{id}")
-  public StudentDetail getStudent(@PathVariable("id") @Size(min = 1, max = 3) String studentId) {
+  public StudentDetail getStudent(
+      @PathVariable("id") @Size(min = 1, max = 3) @Pattern(regexp = "^\\d+$") String studentId) {
     return service.searchStudentDetail(studentId);
   }
 
@@ -71,7 +79,7 @@ public class StudentController {
     // 入力エラーチェック
     if (result.hasErrors()) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-          result.getFieldError().getDefaultMessage());
+          "重複したコース名は登録できません");
     }
     StudentDetail responseStudentDetail = service.registerStudent(studentDetail);
     return ResponseEntity.ok(responseStudentDetail);
@@ -89,6 +97,11 @@ public class StudentController {
       @RequestBody @Valid StudentDetail studentDetail) {
     service.updateStudent(studentDetail);
     return ResponseEntity.ok("更新処理が成功しました。");
+  }
+
+  // エラーを投げる用のメソッド
+  private boolean shouldThrowError() {
+    return true; // 常にエラーを発生させる
   }
 
 }

--- a/src/main/java/raisetech/StudentManagement/data/Student.java
+++ b/src/main/java/raisetech/StudentManagement/data/Student.java
@@ -1,7 +1,7 @@
 package raisetech.StudentManagement.data;
 
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -22,19 +22,28 @@ public class Student {
   @Size(min = 1, max = 10, message = "名前は必須です")
   private String name;
 
-  @NotNull
+  @NotBlank
   private String furigana;
 
+  @NotBlank
   private String nickname;
 
+  @NotBlank
   @Email(message = "無効なメールアドレスです")
   private String emailAddress;
 
+  @NotBlank
   private String residentialArea;
+
+  @NotBlank
   private int age;
+
+  @NotBlank
   @Pattern(regexp = "男性|女性|回答しない", message = "性別は「男性」「女性」「回答しない」のいずれかでなければなりません")
   private String gender;
+
   private String remark;
+
   private boolean isDeleted;
 
 }

--- a/src/main/java/raisetech/StudentManagement/exception/GlobalExceptionHandler.java
+++ b/src/main/java/raisetech/StudentManagement/exception/GlobalExceptionHandler.java
@@ -16,7 +16,7 @@ import org.springframework.web.server.ResponseStatusException;
  * グローバルエラーをハンドリングするクラスです
  */
 @RestControllerAdvice
-public class GlobalExceptionHandler {
+public class GlobalExceptionHandler extends Exception {
 
   /**
    * ResponseStatusExceptionを処理します。

--- a/src/main/java/raisetech/StudentManagement/exception/GlobalExceptionHandler.java
+++ b/src/main/java/raisetech/StudentManagement/exception/GlobalExceptionHandler.java
@@ -16,7 +16,7 @@ import org.springframework.web.server.ResponseStatusException;
  * グローバルエラーをハンドリングするクラスです
  */
 @RestControllerAdvice
-public class GlobalExceptionHandler extends Exception {
+public class GlobalExceptionHandler {
 
   /**
    * ResponseStatusExceptionを処理します。


### PR DESCRIPTION
全件検索のメソッドにエラーを投げてみる専用メソッドを追加しました。

![36回課題_エラーを投げる](https://github.com/user-attachments/assets/b2716ac6-1f28-42c3-8c1a-72ee0e99de27)


※エラーをハンドリングするクラスはすでに作っていたため、明記しておりませんが、
35回課題で作成していたエラー内容表示を以下に掲載します。

![35回課題_更新xml化ffmpeg](https://github.com/user-attachments/assets/e6e4f974-0e52-49cc-8802-77f320f90891)
